### PR TITLE
Fix header in detail view

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,11 +262,25 @@
       display: none;
       opacity: 0;
       transition: opacity 0.4s ease;
-      margin-top: 100px;
+      margin-top: 0;
     }
 
     #detailView.show {
       opacity: 1;
+    }
+
+    #detailView header {
+      position: fixed !important;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 1000;
+      background-color: #2c3e50;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+
+    #detailContent {
+      padding-top: 80px;
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- keep the detail view header fixed at the top of the page
- pad the page content so it doesn't slide under the header

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68539806b52c8333b77102cde9df52b9