### PR TITLE
Add SIM800 USSD execution with LCD feedback

### DIFF
--- a/sim800l_ussd_lcd.ino
+++ b/sim800l_ussd_lcd.ino
@@ -18,6 +18,7 @@ const unsigned long SMS_POLL_INTERVAL_MS = 3000;
 const unsigned long LCD_STATUS_DISPLAY_MS = 1500;
 const unsigned long MODEM_RETRY_INTERVAL_MS = 5000;
 const unsigned long OUTGOING_CALL_WATCH_MS = 45000;
+const unsigned long USSD_RESPONSE_TIMEOUT_MS = 20000;
 unsigned long lastSmsPollMs = 0;
 unsigned long lastModemRetryMs = 0;
 
@@ -113,6 +114,85 @@ String normalizeSmsCommand(String text) {
   text = trimSmsText(text);
   text.toUpperCase();
   return text;
+}
+
+bool isUssdCommand(String text) {
+  text = trimSmsText(text);
+  if (text.length() < 2 || text.charAt(text.length() - 1) != '#') {
+    return false;
+  }
+
+  char firstChar = text.charAt(0);
+  return firstChar == '*' || firstChar == '#';
+}
+
+void showLcdMessage(const String &message) {
+  String cleanMessage = trimSmsText(message);
+  if (cleanMessage.length() == 0) {
+    cleanMessage = "Reponse vide";
+  }
+
+  lcdPrint2Lines(cleanMessage.substring(0, 16), cleanMessage.substring(16, 32));
+}
+
+bool executeUssd(const String &code, String &ussdResponse, bool &hasError) {
+  if (!ensureModemReady()) {
+    ussdResponse = "SIM800 indisponible";
+    hasError = true;
+    return false;
+  }
+
+  while (sim800.available()) sim800.read();
+
+  sim800.print("AT+CUSD=1,\"");
+  sim800.print(code);
+  sim800.println("\",15");
+
+  unsigned long start = millis();
+  String modemResponse = "";
+  hasError = false;
+  ussdResponse = "";
+
+  while (millis() - start < USSD_RESPONSE_TIMEOUT_MS) {
+    while (sim800.available()) {
+      char c = sim800.read();
+      modemResponse += c;
+
+      if (modemResponse.indexOf("+CUSD:") >= 0) {
+        int firstQuote = modemResponse.indexOf('"');
+        int secondQuote = modemResponse.indexOf('"', firstQuote + 1);
+        if (firstQuote >= 0 && secondQuote > firstQuote) {
+          ussdResponse = modemResponse.substring(firstQuote + 1, secondQuote);
+        } else {
+          ussdResponse = "+CUSD recu";
+        }
+        return true;
+      }
+
+      if (modemResponse.indexOf("ERROR") >= 0) {
+        hasError = true;
+        ussdResponse = "Erreur USSD";
+        return false;
+      }
+    }
+  }
+
+  hasError = true;
+  ussdResponse = "Pas de reponse";
+  return false;
+}
+
+void handleUssdRequest(const String &ussdCode) {
+  String ussdResponse;
+  bool hasError = false;
+  executeUssd(ussdCode, ussdResponse, hasError);
+
+  Serial.print("USSD ");
+  Serial.print(ussdCode);
+  Serial.print(" -> ");
+  Serial.println(ussdResponse);
+
+  showLcdMessage(ussdResponse);
 }
 
 String generateCode4() {
@@ -322,6 +402,8 @@ void processUnreadSms() {
       if (called) {
         monitorOutgoingCallAndHangup();
       }
+    } else if (isUssdCommand(smsBody)) {
+      handleUssdRequest(trimSmsText(smsBody));
     } else {
       Serial.println("SMS ignore (commande non geree)");
     }


### PR DESCRIPTION
### Motivation
- Allow the sketch to execute USSD codes received by SMS (e.g. `#359#` or `*123#`) and show the modem response or an error on the LCD.
- Keep existing SMS command flows (`CODE` and `APPEL`) unchanged and make a minimal, focused change inside SMS handling.

### Description
- Added a new timeout constant `USSD_RESPONSE_TIMEOUT_MS` and helper `isUssdCommand(String)` to detect USSD-like SMS bodies.
- Implemented `executeUssd(...)` to send `AT+CUSD=1,"<code>",15`, wait for `+CUSD:` or `ERROR`, and parse the returned text or error/timeout.
- Added `showLcdMessage(...)` and `handleUssdRequest(...)` to present the USSD response (or error/timeout) on the 16x2 I2C LCD.
- Integrated the USSD path into unread-SMS processing so that when a received SMS is a USSD code it is executed and the result is displayed; existing `CODE` and `APPEL` branches remain unchanged.

### Testing
- Static content checks verifying presence of `USSD_RESPONSE_TIMEOUT_MS`, `isUssdCommand`, `executeUssd`, and the SMS hook were run and reported OK.
- The modified file `sim800l_ussd_lcd.ino` was inspected to confirm the change is limited to USSD handling and SMS-processing wiring, and the inserted code is syntactically consistent with surrounding code.
- The Arduino toolchain / hardware compile could not be executed in this environment because the Arduino CLI/tooling is not available, so no hardware-targeted build or runtime tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beb79ac3e4832a81fc05db3c4cdf44)