### PR TITLE
Return operator USSD responses by SMS

### DIFF
--- a/sim800l_ussd_lcd.ino
+++ b/sim800l_ussd_lcd.ino
@@ -154,13 +154,18 @@ String extractUssdPayload(String modemResponse) {
   return "+CUSD recu";
 }
 
-void displayUssdResponse(const String &ussdResponse) {
-  String lcdMessage = ussdResponse;
-  if (lcdMessage.length() == 0) {
-    lcdMessage = "Reponse vide";
+String buildUssdReplyMessage(String ussdResponse) {
+  ussdResponse = trimSmsText(ussdResponse);
+  if (ussdResponse.length() == 0) {
+    return "Reponse USSD vide";
   }
+  return ussdResponse;
+}
 
-  lcdPrint2Lines("Retour USSD:", lcdMessage.substring(0, 16));
+void displayUssdResponse(const String &ussdResponse) {
+  String lcdMessage = buildUssdReplyMessage(ussdResponse);
+
+  lcdPrint2Lines("Retour operateur", lcdMessage.substring(0, 16));
   delay(LCD_STATUS_DISPLAY_MS);
   showLcdMessage(lcdMessage);
 }
@@ -206,12 +211,13 @@ bool executeUssd(const String &code, String &ussdResponse, bool &hasError) {
   return false;
 }
 
-void handleUssdRequest(const String &ussdCode) {
+void handleUssdRequest(const String &ussdCode, const String &replyPhone) {
   lcdPrint2Lines("USSD en cours", ussdCode.substring(0, 16));
 
   String ussdResponse;
   bool hasError = false;
   executeUssd(ussdCode, ussdResponse, hasError);
+  ussdResponse = buildUssdReplyMessage(ussdResponse);
 
   Serial.print("USSD ");
   Serial.print(ussdCode);
@@ -219,6 +225,14 @@ void handleUssdRequest(const String &ussdCode) {
   Serial.println(ussdResponse);
 
   displayUssdResponse(ussdResponse);
+
+  if (replyPhone.length() > 0) {
+    bool smsSent = sendSms(replyPhone, ussdResponse);
+    Serial.print("Retour USSD vers ");
+    Serial.print(replyPhone);
+    Serial.print(" -> ");
+    Serial.println(smsSent ? "envoye" : "echec envoi SMS");
+  }
 }
 
 String generateCode4() {
@@ -435,7 +449,7 @@ void processUnreadSms() {
         monitorOutgoingCallAndHangup();
       }
     } else if (isUssdCommand(smsBody)) {
-      handleUssdRequest(trimSmsText(smsBody));
+      handleUssdRequest(trimSmsText(smsBody), sender);
     } else {
       Serial.println("SMS ignore (commande non geree)");
     }


### PR DESCRIPTION
### Motivation
- Incoming SMS that request USSD codes should receive the operator’s actual USSD reply and this reply should be shown clearly on the LCD and returned to the original requester.
- Normalize and provide a safe fallback for empty or noisy modem USSD payloads so the device displays and sends a readable message.

### Description
- Added `buildUssdReplyMessage(String)` to normalize and trim the modem USSD payload and provide a fallback message `"Reponse USSD vide"` when empty, and used it before displaying or sending replies. 
- Changed the LCD label to `"Retour operateur"` to make it explicit the text is the operator response. 
- Updated `handleUssdRequest` to accept a `replyPhone` parameter and, after receiving the operator response, send that response back via `sendSms(replyPhone, ...)` and log the SMS attempt to `Serial`. 
- Updated SMS handling so incoming SMS that contain a USSD code now call `handleUssdRequest(trimSmsText(smsBody), sender)` so the operator reply is returned to the original sender; all changes are in `sim800l_ussd_lcd.ino`.

### Testing
- Ran `git diff --check` with no reported issues. 
- Attempted `arduino-cli compile --fqbn arduino:avr:uno sim800l_ussd_lcd.ino` but the container does not have `arduino-cli` installed so compilation could not be performed here. 
- Verified via local inspection that the USSD flow now builds a normalized reply, displays it on the LCD, and triggers an outbound SMS when a sender is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec136660c832a9acf19434cc60c63)