### PR TITLE
Return USSD responses as strings

### DIFF
--- a/sim800l_ussd_lcd.ino
+++ b/sim800l_ussd_lcd.ino
@@ -186,11 +186,9 @@ void displayUssdResponse(const String &ussdResponse) {
   showLcdMessage(lcdMessage);
 }
 
-bool executeUssd(const String &code, String &ussdResponse, bool &hasError) {
+String executeUssd(const String &code) {
   if (!ensureModemReady()) {
-    ussdResponse = "error";
-    hasError = true;
-    return false;
+    return "error";
   }
 
   while (sim800.available()) sim800.read();
@@ -202,8 +200,6 @@ bool executeUssd(const String &code, String &ussdResponse, bool &hasError) {
   unsigned long start = millis();
   String modemResponse = "";
   String modemLine = "";
-  hasError = false;
-  ussdResponse = "";
 
   while (millis() - start < USSD_RESPONSE_TIMEOUT_MS) {
     while (sim800.available()) {
@@ -226,33 +222,26 @@ bool executeUssd(const String &code, String &ussdResponse, bool &hasError) {
       }
 
       if (modemLine.startsWith("+CUSD:")) {
-        ussdResponse = extractUssdPayload(modemLine);
-        hasError = isUssdErrorStatus(extractUssdStatus(modemLine)) || ussdResponse.length() == 0;
-        return !hasError;
+        String ussdResponse = extractUssdPayload(modemLine);
+        bool hasError = isUssdErrorStatus(extractUssdStatus(modemLine)) || ussdResponse.length() == 0;
+        return buildUssdReplyMessage(ussdResponse, hasError);
       }
 
       if (modemLine.indexOf("ERROR") >= 0 || modemResponse.indexOf("ERROR") >= 0) {
-        hasError = true;
-        ussdResponse = "error";
-        return false;
+        return "error";
       }
 
       modemLine = "";
     }
   }
 
-  hasError = true;
-  ussdResponse = "error";
-  return false;
+  return "error";
 }
 
 void handleUssdRequest(const String &ussdCode, const String &replyPhone) {
   lcdPrint2Lines("USSD en cours", ussdCode.substring(0, 16));
 
-  String ussdResponse;
-  bool hasError = false;
-  executeUssd(ussdCode, ussdResponse, hasError);
-  ussdResponse = buildUssdReplyMessage(ussdResponse, hasError);
+  String ussdResponse = executeUssd(ussdCode);
 
   Serial.print("USSD ");
   Serial.print(ussdCode);


### PR DESCRIPTION
### Motivation
- The USSD handling mixed boolean return values and output parameters which made it awkward to treat USSD replies as textual responses; the expected USSD responses should be strings.

### Description
- Changed `executeUssd` to return a `String` containing the normalized USSD reply instead of using a boolean return plus output parameters. (file: `sim800l_ussd_lcd.ino`)
- Kept response normalization through `buildUssdReplyMessage` so empty or error responses become the string `"error"` consistently.
- Simplified `handleUssdRequest` to call the new `executeUssd` signature and consume the returned `String` directly for LCD display and SMS forwarding.
- Removed the now-unused out-parameters and related boolean plumbing from the USSD flow.

### Testing
- Ran `rg -n "executeUssd\("` to verify call sites were updated and it succeeded.
- Ran `git diff --check` and it returned clean (no whitespace/merge errors).
- Ran `clang-format --dry-run --Werror` which reported formatting violations on `sim800l_ussd_lcd.ino` and therefore failed; file needs formatting to satisfy the style check.
- Checked for `arduino-cli` in the environment and it was not available, so a firmware compilation was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec9e30648832aaf29a10f8287544a)